### PR TITLE
Fix conversion helpers and CSV export

### DIFF
--- a/lib/lidar_driver.py
+++ b/lib/lidar_driver.py
@@ -244,7 +244,6 @@ class Lidar:
 
     def pwm_from_speed(self, speed):
         m, b = self.pwm_coeffs
-        self.pwm_coeffs
         return (speed - b) / m
 
 

--- a/lib/pano_utils.py
+++ b/lib/pano_utils.py
@@ -162,13 +162,14 @@ def spherical_to_longlat(uv):
     return longitude, latitude
 
 
-def deg2rad(rad_list):
-    # deg_list = [math.degrees(item) for item in rad_list]  # list comprehension
-    return tuple(map(math.degrees, rad_list))
-
-
-def rad2deg(deg_list):
+def deg2rad(deg_list):
+    """Convert iterable of degrees to radians."""
     return tuple(map(math.radians, deg_list))
+
+
+def rad2deg(rad_list):
+    """Convert iterable of radians to degrees."""
+    return tuple(map(math.degrees, rad_list))
 
 
 def mod(angles, mod=math.pi*2):

--- a/lib/pointcloud.py
+++ b/lib/pointcloud.py
@@ -310,6 +310,8 @@ def save_pointcloud(pcd, filepath, ply_ascii=False, ply_compression=True, csv_de
     elif ext == "csv":
         if not isinstance(pcd, np.ndarray):
             array = np.asarray(pcd.points)
+        else:
+            array = pcd
         np.savetxt(filepath, array, delimiter=csv_delimiter)
 
     elif ext == "e57":


### PR DESCRIPTION
## Summary
- correct radian/degree conversion helpers
- ensure numpy arrays are handled when exporting CSV
- remove stray statement in PWM conversion

## Testing
- `flake8 .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'open3d')*

------
https://chatgpt.com/codex/tasks/task_b_684b20462c4483269f0cc468a806541b