### PR TITLE
Document PiLiDAR Pi 5 workflow and enable PWM stepper control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
-# PiLiDAR – DIY 360° 3D Panorama Scanner
+# PiLiDAR – Vollautomatischer 3D-Scanner für den Raspberry Pi 5
 
-PiLiDAR kombiniert einen LiDAR Sensor, eine Kamera und einen getriebeübersetzten
-Schrittmotor zu einem vollständigen 3D-Scanner. Dieses Repository enthält einen
-kompletten, kommentierten Workflow – vom Aufnehmen der Rohdaten über das
-Stitchen eines Panoramas bis hin zur Erzeugung farbiger Punktwolken.
+Diese Version von **PiLiDAR** richtet sich vollständig auf den Raspberry Pi 5
+aus.  Sie kombiniert den über **USB** angebundenen **STL27L LiDAR**, eine
+**Raspberry Pi Camera Module 2** und einen über einen **A4988** Treiber
+angeschlossenen **NEMA17 Schrittmotor mit Planetengetriebe**.  Ziel des
+Projekts ist es, absolute Einsteiger*innen sicher zum fertigen Scan zu führen –
+vom Erfassen der Rohdaten über das automatische Panoramastitching bis hin zur
+farbigen Punktwolke.
 
-Die folgenden Kapitel erklären jeden Schritt so, dass auch absolute
-Einsteiger*innen sicher zum Ergebnis kommen.
+*Keine Zusatzhardware nötig*: Es werden **keine** Taster, I²C-Sensoren oder
+Beschleunigungssensoren verbaut.  Alle Geräte werden rein per Software
+gesteuert.
+
+Die folgenden Kapitel führen dich kommentiert durch den kompletten Workflow.
 
 ---
 
@@ -29,28 +35,36 @@ Einsteiger*innen sicher zum Ergebnis kommen.
    pip install -r requirements.txt
    ```
 
-3. **Hardware anschließen**
+3. **Hardware verbinden**  
+   Die Tabelle zeigt, welche Pins auf dem Raspberry Pi 5 genutzt werden.  Die
+   Ansteuerung erfolgt ausschließlich über PWM-Impulse am STEP-Pin des A4988.
 
-   - LDRobot STL27L LiDAR
-   - Raspberry Pi HQ Kamera (oder kompatibel)
-   - NEMA17 Schrittmotor mit A4988 Treiber und Planetengetriebe
-   - Stromversorgung: 5 V für den LiDAR, 12 V bzw. passender Akku für den Motor
+   | Komponente | Anschluss | Pi-GPIO |
+   |------------|-----------|---------|
+   | STL27L LiDAR | USB-Kabel | USB 3.0 Port (blau) |
+   | A4988 DIR    | Richtung des Motors | GPIO 26 |
+   | A4988 STEP   | PWM-Impulse | GPIO 19 |
+   | A4988 ENABLE | Aktiviert den Treiber (Low = aktiv) | GPIO 17 |
+   | A4988 MS1–MS3 | Mikrostepping (16 ×) | GPIO 5, 6, 13 |
+   | Relais für Motorversorgung | Schaltet Stepper-Strom | GPIO 24 |
+   | Kamera | CSI-Anschluss | Raspberry Pi Camera Module 2 |
 
-   Achte darauf, dass der Motor aufgrund des Getriebes langsam, aber sehr
-   gleichmäßig bewegt wird. Die voreingestellten Mikroschritte und die im
-   Code verwendeten Pausen sind darauf abgestimmt.
+   *Warum kein Taster?*  Der komplette Ablauf startet per Software (GUI oder
+   Kommandozeile).  Zusätzliche Schalter würden Einsteiger*innen nur verwirren
+   – daher verzichten wir bewusst darauf.
 
-4. **Serielle Schnittstelle freischalten (nur Raspberry Pi)**
+4. **Serielle Schnittstelle freigeben**  
+   Der STL27L meldet sich als `/dev/ttyUSB0`.  Der folgende Befehl sorgt dafür,
+   dass der Pi ohne Root-Rechte darauf zugreifen kann:
 
    ```bash
-   sudo chmod a+rw /dev/ttyUSB0  # oder /dev/ttyS0 je nach Anschluss
+   sudo chmod a+rw /dev/ttyUSB0
    ```
 
-5. **Optionale Extras**
-
-   - Ein Taster kann über `gpio_interrupt.py` (liegt nun im Ordner `old/`) zum
-     Starten genutzt werden.
-   - Für eine automatische Panoramaerstellung sollte Hugin installiert sein.
+5. **Panorama-Software (optional aber empfohlen)**  
+   Für das automatische Stitchen sollte [Hugin](https://hugin.sourceforge.io/)
+   installiert sein.  Unter Raspberry Pi OS gelingt das mit `sudo apt install
+   hugin-tools`.
 
 ---
 
@@ -58,8 +72,9 @@ Einsteiger*innen sicher zum Ergebnis kommen.
 
 ### 2.1 Grafische Benutzeroberfläche
 
-Die GUI richtet sich an Einsteiger*innen. Sie ermöglicht das Anpassen der
-wichtigsten Parameter und das Starten/Stoppen des Scans.
+Die GUI richtet sich an Einsteiger*innen.  Sie erklärt jeden Schritt und
+startet den vollautomatischen Workflow (LiDAR lesen → Motor drehen → Fotos
+aufnehmen → Panorama → Punktwolke) per Mausklick.
 
 ```bash
 python PiLiDAR.py --gui
@@ -82,8 +97,24 @@ Wer direkt per Terminal arbeiten möchte, startet einfach:
 python PiLiDAR.py
 ```
 
-Der Lauf erzeugt automatisch alle Daten. Abbruch ist jederzeit mit `Strg+C`
-möglich, der Controller stoppt den Motor und legt die Geräte sicher still.
+Der Lauf erzeugt automatisch alle Daten.  Abbruch ist jederzeit mit `Strg+C`
+möglich, der Controller stoppt den Motor, deaktiviert den A4988 über den
+ENABLE-Pin und fährt den LiDAR geordnet herunter.
+
+### 2.3 Was im Hintergrund passiert
+
+1. **Initialisierung** – Das Skript erstellt den Scan-Ordner, schaltet das
+   Motor-Relais ein und aktiviert den A4988 über den ENABLE-Pin.
+2. **Kamera-Kalibrierung** – Die Belichtung wird automatisch bestimmt, sodass
+   die Bilder für das Panorama konsistent sind.
+3. **Fotoaufnahme** – Der Stepper dreht den Aufbau in gleichmäßigen 90°-Schritten
+   (die Pulsweite wird per PWM erzeugt) und löst die Kamera aus.
+4. **LiDAR-Scan** – Der STL27L liefert über USB die Messpakete.  Der Motor wird
+   synchron per PWM-Impulsen bewegt, bis der gesamte Scanwinkel abgefahren ist.
+5. **Panorama & Punktwolken** – Hugin erstellt aus den Bildern ein Panorama, das
+   anschließend genutzt wird, um die Punktwolke farblich einzufärben.
+6. **Aufräumen** – LiDAR-Motor und Stepper werden gestoppt, der A4988 deaktiviert
+   und das Relais freigegeben.  Dadurch ist der Aufbau sofort wieder sicher.
 
 ---
 
@@ -104,8 +135,7 @@ scans/<SCAN-ID>/
 ```
 
 Alle Dateien werden automatisch erzeugt und mit sprechenden Namen versehen.
-
----
+Eine manuelle Nacharbeit ist nicht notwendig.
 
 ## 4. Welche LiDAR-Daten werden gespeichert?
 
@@ -149,15 +179,17 @@ Arbeitsschritt nachvollziehen.
 
 ## 6. Hardwarehinweise
 
-- **Stepper & Getriebe**: Der Motor wird mit 16-fach Mikrostepping betrieben.
-  Durch das Planetengetriebe entsteht eine ruhige, ruckfreie Bewegung. Die
-  Parameter `STEP_DELAY` und `SCAN_DELAY` im `config.json` können bei Bedarf
-  feinjustiert werden.
-- **LiDAR-Stromversorgung**: Der Treiber kann den Sensor über das Board
-  ein- und ausschalten (`power_on()` / `power_off()` im Code). Ein externes
-  Relais ist nicht notwendig.
+- **Stepper & Getriebe**: Der Motor läuft mit 16-fach Mikrostepping.  Die
+  Schrittimpulse werden als 50 % PWM über den STEP-Pin erzeugt.  Die Frequenz
+  ergibt sich aus `STEP_DELAY` in der `config.json` und sorgt für einen sehr
+  gleichmäßigen Lauf des getriebeübersetzten Motors.
+- **Enable-Pin**: Der A4988 ist standardmäßig deaktiviert (Enable = High).  Die
+  Software zieht den Pin bei Bedarf auf Low und gibt den Motor nach dem Scan
+  sofort wieder frei – so bleibt er handwarm und sicher.
+- **LiDAR-Stromversorgung**: Der Sensor wird ausschließlich über USB versorgt,
+  zusätzliche Relais oder I²C-Module sind nicht nötig.
 - **Panorama**: Für bestmögliche Ergebnisse sollten alle Bilder mit identischer
-  Belichtung aufgenommen werden. Die automatisch ermittelten Werte sind ein
+  Belichtung aufgenommen werden.  Die automatisch ermittelten Werte sind ein
   guter Ausgangspunkt; bei Bedarf lassen sie sich im GUI anpassen.
 
 ![PiLiDAR v2](images/pilidar_covershot_v2.jpg)

--- a/config.json
+++ b/config.json
@@ -42,6 +42,7 @@
         "pins": {
             "DIR_PIN": 26,
             "STEP_PIN": 19,
+            "ENABLE_PIN": 17,
             "MS_PINS": [5, 6, 13]
         },
         "RELAY_PIN": 24,

--- a/lib/a4988_driver.py
+++ b/lib/a4988_driver.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import os
 from time import sleep
-from typing import Iterable
+from typing import Iterable, Optional
 
 # ---------------------------------------------------------------------------
 # GPIO fallback for non Raspberry Pi systems
@@ -42,6 +42,7 @@ except Exception:  # pragma: no cover - triggered on CI or development machines
 
         def __init__(self) -> None:
             self._pins = {}
+            self._pwms = {}
 
         def setwarnings(self, _: bool) -> None:
             pass
@@ -54,6 +55,31 @@ except Exception:  # pragma: no cover - triggered on CI or development machines
 
         def output(self, pin: int, state: bool) -> None:
             self._pins[pin] = state
+
+        class _MockPWM:
+            def __init__(self, pin: int, frequency: float) -> None:
+                self.pin = pin
+                self.frequency = frequency
+                self.duty_cycle = 0.0
+                self.running = False
+
+            def start(self, duty_cycle: float) -> None:
+                self.duty_cycle = duty_cycle
+                self.running = True
+
+            def ChangeFrequency(self, frequency: float) -> None:
+                self.frequency = frequency
+
+            def ChangeDutyCycle(self, duty_cycle: float) -> None:
+                self.duty_cycle = duty_cycle
+
+            def stop(self) -> None:
+                self.running = False
+
+        def PWM(self, pin: int, frequency: float):
+            pwm = self._MockPWM(pin, frequency)
+            self._pwms[pin] = pwm
+            return pwm
 
         def cleanup(self, pins: Iterable[int] | int | None = None) -> None:
             if pins is None:
@@ -89,6 +115,9 @@ class A4988:
         step_angle: float = 1.8,
         microsteps: int = 16,
         gear_ratio: float = 1.0,
+        enable_pin: Optional[int] = None,
+        pwm_frequency: Optional[float] = None,
+        use_pwm: bool = False,
         verbose: bool = False,
     ) -> None:
 
@@ -104,12 +133,18 @@ class A4988:
         self.dir_pin = dir_pin
         self.step_pin = step_pin
         self.ms_pins = list(ms_pins)
+        self.enable_pin = enable_pin
 
         # Configure the GPIO pins as outputs.
         GPIO.setup(self.dir_pin, GPIO.OUT)
         GPIO.setup(self.step_pin, GPIO.OUT)
         for pin in self.ms_pins:
             GPIO.setup(pin, GPIO.OUT)
+        if self.enable_pin is not None:
+            GPIO.setup(self.enable_pin, GPIO.OUT)
+            # Enable-Pin ist low-aktiv.  Wir lassen den Treiber deaktiviert,
+            # bis tatsächlich Bewegungen anstehen.
+            GPIO.output(self.enable_pin, GPIO.HIGH)
 
         # Internal state that allows us to keep track of the absolute angle.
         self.current_steps = 0
@@ -119,6 +154,15 @@ class A4988:
         self.microsteps = microsteps
         self.gear_ratio = gear_ratio
         self.delay = delay
+        self._supports_pwm = hasattr(GPIO, "PWM")
+        self.use_pwm = bool(use_pwm and self._supports_pwm)
+        self._pwm: Optional[object] = None
+        # PWM-Frequenz: aus der eingestellten Verzögerung berechnet oder vom
+        # Aufrufer vorgegeben.  Ein Minimum von 1 Hz verhindert Division durch 0.
+        base_frequency = 1.0 / max(self.delay, 0.0001)
+        self.pwm_frequency = max(pwm_frequency or base_frequency, 1.0)
+        # sehr kurze Bewegungen arbeiten stabiler mit manuellen Einzelimpulsen
+        self._pwm_min_steps = 8
 
         # Microstepping allows very gentle motion because the driver performs
         # fractional steps.  The mapping below comes straight from the
@@ -134,6 +178,28 @@ class A4988:
         if self.microsteps in self.step_modes:
             for pin, state in zip(self.ms_pins, self.step_modes[self.microsteps]):
                 GPIO.output(pin, state)
+
+    # ------------------------------------------------------------------
+    # Helper functions for enable/PWM handling
+    # ------------------------------------------------------------------
+    def enable(self) -> None:
+        """Activate the stepper driver."""
+
+        if self.enable_pin is not None:
+            GPIO.output(self.enable_pin, GPIO.LOW)
+
+    def disable(self) -> None:
+        """Disable the stepper driver."""
+
+        if self.enable_pin is not None:
+            GPIO.output(self.enable_pin, GPIO.HIGH)
+
+    def _ensure_pwm(self):
+        if not self._supports_pwm:
+            raise RuntimeError("PWM support not available on this platform")
+        if self._pwm is None:
+            self._pwm = GPIO.PWM(self.step_pin, self.pwm_frequency)
+        return self._pwm
 
     def set_direction(self, direction: bool) -> None:
         """Set the turning direction of the motor shaft."""
@@ -159,6 +225,7 @@ class A4988:
         gearbox is engaged.
         """
 
+        self.enable()
         GPIO.output(self.step_pin, True)
         sleep(0.0001)
         GPIO.output(self.step_pin, False)
@@ -175,12 +242,14 @@ class A4988:
         direction = steps < 0
         steps = abs(int(steps))
 
-        self.set_direction(direction)
-        for _ in range(steps):
-            self.step()
+        if steps == 0:
+            return
 
-        # update current steps considering direction
-        self.current_steps += steps if not direction else -steps
+        self.set_direction(direction)
+        if self.use_pwm and self._supports_pwm and steps >= self._pwm_min_steps:
+            self._move_steps_pwm(steps, direction)
+        else:
+            self._move_steps_manual(steps, direction)
 
     def move_angle(self, angle: float) -> int:
         """Convenience wrapper that accepts a rotation in degrees."""
@@ -188,6 +257,30 @@ class A4988:
         steps = self.get_steps_for_angle(abs(angle))
         self.move_steps(steps if angle >= 0 else -steps)
         return steps
+
+    # ------------------------------------------------------------------
+    # internal movement helpers
+    # ------------------------------------------------------------------
+    def _move_steps_manual(self, steps: int, direction: bool) -> None:
+        self.enable()
+        for _ in range(steps):
+            self.step()
+        self.current_steps += steps if not direction else -steps
+
+    def _move_steps_pwm(self, steps: int, direction: bool) -> None:
+        self.enable()
+        pwm = self._ensure_pwm()
+        pwm.ChangeFrequency(self.pwm_frequency)
+        pwm.ChangeDutyCycle(50.0)
+        pwm.start(50.0)
+
+        # Ein PWM-Zyklus liefert genau einen Step-Impuls (Rising Edge).
+        duration = steps / self.pwm_frequency
+        sleep(duration)
+        pwm.stop()
+        GPIO.output(self.step_pin, False)
+
+        self.current_steps += steps if not direction else -steps
 
     def move_to_angle(self, target_angle: float, mod: bool = True) -> None:
         """Rotate the platform to an absolute target angle.
@@ -222,9 +315,19 @@ class A4988:
     def close(self) -> None:
         """Release the GPIO pins."""
 
+        if self._pwm is not None:
+            try:
+                self._pwm.stop()
+            except AttributeError:
+                pass
+            self._pwm = None
+
+        self.disable()
         GPIO.cleanup(self.ms_pins)
         GPIO.cleanup(self.dir_pin)
         GPIO.cleanup(self.step_pin)
+        if self.enable_pin is not None:
+            GPIO.cleanup(self.enable_pin)
 
 
 if __name__ == "__main__":
@@ -240,13 +343,15 @@ if __name__ == "__main__":
     scan_delay = config.get("STEPPER", "SCAN_DELAY")  # 1 / (SAMPLING_RATE * TARGET_RES / 360)
     
     # initialize stepper
-    stepper = A4988(config.get("STEPPER", "pins", "DIR_PIN"), 
-                    config.get("STEPPER", "pins", "STEP_PIN"), 
-                    config.get("STEPPER", "pins", "MS_PINS"), 
+    stepper = A4988(config.get("STEPPER", "pins", "DIR_PIN"),
+                    config.get("STEPPER", "pins", "STEP_PIN"),
+                    config.get("STEPPER", "pins", "MS_PINS"),
                     delay      = config.get("STEPPER", "STEP_DELAY"),  # 0.001
                     step_angle = config.get("STEPPER", "STEP_ANGLE"),  # 360 / STEPPER_RES
                     microsteps = config.get("STEPPER", "MICROSTEPS"),  # 16
-                    gear_ratio = config.get("STEPPER", "GEAR_RATIO"))  # 1 + 38/14 
+                    gear_ratio = config.get("STEPPER", "GEAR_RATIO"),
+                    enable_pin = config.get("STEPPER", "pins", "ENABLE_PIN", default=None),
+                    use_pwm    = True)  # demonstriert den PWM-Betrieb
 
 
     # # TEST: MOVE FULL 360° FORWARD AND BACKWARD

--- a/lib/config.py
+++ b/lib/config.py
@@ -63,12 +63,13 @@ class Config:
         self.platform = get_platform()
         self.GPIO = GPIO
         self.set_device(self.get("LIDAR", "DEVICE"))
-        
-        
+
+
         # STEPPER
         self.STEPPER_RES = self.get("STEPPER", "STEPPER_RES")
         self.MICROSTEPS = self.get("STEPPER", "MICROSTEPS")
         self.SCAN_ANGLE = self.get("STEPPER", "SCAN_ANGLE")
+        self.stepper_enable_pin = self.get("STEPPER", "pins", "ENABLE_PIN", default=None)
 
         step_angle = 360 / self.get("STEPPER", "STEPPER_RES")
         self.set(step_angle, "STEPPER", "STEP_ANGLE")
@@ -229,6 +230,11 @@ class Config:
         self.relay_pin = self.get("STEPPER", "RELAY_PIN")
         self.GPIO.setup(self.relay_pin, self.GPIO.OUT)
         self.GPIO.output(self.relay_pin, self.GPIO.HIGH)  # enable power
+
+        if self.stepper_enable_pin is not None:
+            self.GPIO.setup(self.stepper_enable_pin, self.GPIO.OUT)
+            # High = deaktiviert → verhindert unkontrolliertes Anlaufen beim Booten
+            self.GPIO.output(self.stepper_enable_pin, self.GPIO.HIGH)
 
         if self.lidar_power_pin is not None:
             self.GPIO.setup(self.lidar_power_pin, self.GPIO.OUT)

--- a/lib/scan_controller.py
+++ b/lib/scan_controller.py
@@ -43,10 +43,13 @@ class ScanController:
             config.get("STEPPER", "pins", "DIR_PIN"),
             config.get("STEPPER", "pins", "STEP_PIN"),
             pins,
+            enable_pin=config.get("STEPPER", "pins", "ENABLE_PIN", default=None),
             delay=config.get("STEPPER", "STEP_DELAY"),
             step_angle=config.get("STEPPER", "STEP_ANGLE"),
             microsteps=config.get("STEPPER", "MICROSTEPS"),
             gear_ratio=config.get("STEPPER", "GEAR_RATIO"),
+            pwm_frequency=None,
+            use_pwm=True,
         )
 
     def _default_lidar_factory(self, config):  # pragma: no cover - hardware specific


### PR DESCRIPTION
## Summary
- rewrite the README so beginners can follow the full Raspberry Pi 5 workflow with the STL27L LiDAR, Pi Camera Module 2 and the A4988 driven stepper
- add the A4988 enable pin to the configuration, initialise it safely on boot and drive the stepper via PWM pulses for smooth motion
- update the scan controller to use the new PWM-aware driver so the automated scan pipeline powers devices up and down correctly

## Testing
- pytest
- python -m compileall lib PiLiDAR.py

------
https://chatgpt.com/codex/tasks/task_b_68d3224929ac8326bee0d2ea674c366f