### PR TITLE
Bugfixes, System-Dashboard und Scan-Verwaltung

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -9,11 +9,20 @@ from __future__ import annotations
 
 import asyncio
 import os
+import subprocess
+import time
 from pathlib import Path
 
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import Body, FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
+
+try:
+    import psutil as _psutil
+except ImportError:
+    _psutil = None
+
+_net_prev: dict = {}  # {iface: (bytes_sent, bytes_recv, timestamp)}
 
 from .config import config
 from .controller import ScanController
@@ -102,6 +111,59 @@ async def api_cal_rotation():
 async def api_cal_offset():
     result = await asyncio.to_thread(controller.run_offset_calibration)
     return result
+
+
+@app.get("/api/system/stats")
+async def api_system_stats():
+    if _psutil is None:
+        return {"available": False}
+    cpu = _psutil.cpu_percent(interval=None)
+    ram = _psutil.virtual_memory().percent
+    net: dict = {}
+    try:
+        counters = _psutil.net_io_counters(pernic=True)
+        now = time.monotonic()
+        for iface in ("eth0", "wlan0", "bnep0", "end0"):
+            if iface not in counters:
+                continue
+            c = counters[iface]
+            if iface in _net_prev:
+                prev_sent, prev_recv, prev_t = _net_prev[iface]
+                dt = max(1e-3, now - prev_t)
+                net[iface] = {
+                    "tx_bps": int((c.bytes_sent - prev_sent) / dt),
+                    "rx_bps": int((c.bytes_recv - prev_recv) / dt),
+                }
+            else:
+                net[iface] = {"tx_bps": 0, "rx_bps": 0}
+            _net_prev[iface] = (c.bytes_sent, c.bytes_recv, now)
+    except Exception:
+        pass
+    return {"available": True, "cpu_percent": cpu, "ram_percent": ram, "net": net}
+
+
+@app.post("/api/system/reboot")
+async def api_reboot():
+    subprocess.run(["sudo", "systemctl", "reboot"], check=False)
+    return {"ok": True}
+
+
+@app.post("/api/system/poweroff")
+async def api_poweroff():
+    subprocess.run(["sudo", "systemctl", "poweroff"], check=False)
+    return {"ok": True}
+
+
+@app.delete("/api/scans/{scan_id}")
+async def api_scan_delete(scan_id: str):
+    controller.store.delete_scan(scan_id)
+    return {"ok": True}
+
+
+@app.post("/api/scans/{scan_id}/annotation")
+async def api_scan_annotation(scan_id: str, payload: dict = Body(...)):
+    controller.store.update_annotation(scan_id, str(payload.get("text", "")))
+    return {"ok": True}
 
 
 @app.post("/api/config/apply")

--- a/backend/controller.py
+++ b/backend/controller.py
@@ -179,10 +179,18 @@ class ScanController:
         cfg = self.cfg.MODE_A_STEPWISE
         scan_angle = cfg["SCAN_ANGLE"]
         spm = max(1, int(cfg["STEPS_PER_MEASURE"]))
-        delay = cfg["SCAN_DELAY"]
+        delay = float(cfg["SCAN_DELAY"])
+        max_pkgs = int(cfg["MAX_PACKAGES"])
+        timeout = delay * 5  # maximale Wartezeit pro Schritt
+
         while self.stepper.get_current_angle() < scan_angle and self.state == STATE_SCANNING:
             self.stepper.move_steps(spm)
-            time.sleep(delay)
+            pkgs_before = self.lidar.stats.packets_ok
+            deadline = time.monotonic() + timeout
+            while time.monotonic() < deadline and self.state == STATE_SCANNING:
+                if self.lidar.stats.packets_ok - pkgs_before >= max_pkgs:
+                    break
+                time.sleep(0.005)
 
     def _run_mode_b(self) -> None:
         cfg = self.cfg.MODE_B_CONTINUOUS

--- a/backend/hardware/lidar.py
+++ b/backend/hardware/lidar.py
@@ -78,6 +78,12 @@ class LidarStats:
     bytes_read: int = 0
     last_speed_dps: float = 0.0
     started_at: float = field(default_factory=time.monotonic)
+    _final_rate: float | None = field(default=None, init=False, repr=False)
+
+    def freeze(self) -> None:
+        """Rate beim Stopp einfrieren, damit sie danach nicht weiter sinkt."""
+        dt = max(1e-6, time.monotonic() - self.started_at)
+        self._final_rate = self.packets_ok / dt
 
     @property
     def crc_error_rate(self) -> float:
@@ -86,6 +92,8 @@ class LidarStats:
 
     @property
     def packet_rate(self) -> float:
+        if self._final_rate is not None:
+            return self._final_rate
         dt = max(1e-6, time.monotonic() - self.started_at)
         return self.packets_ok / dt
 
@@ -142,6 +150,7 @@ class LidarReader:
         self._thread.start()
 
     def stop(self) -> None:
+        self.stats.freeze()
         self._running.clear()
         if self._thread is not None:
             self._thread.join(timeout=2.0)

--- a/backend/qa.py
+++ b/backend/qa.py
@@ -31,9 +31,12 @@ def rpm_stability(frames: list[dict]) -> dict:
 def loop_closure_residual(frames, angle_offset, position_offset, dist_min, dist_max,
                           scan_angle, overlap_deg, max_pts=4000) -> float | None:
     """Mittlerer Nächster-Nachbar-Abstand [mm] zwischen Anfangs- und
-    Überlappungs-Sektor. Großer Wert ⇒ Schrittverlust/Schlupf/Fehlkalibrierung."""
+    Überlappungs-Sektor. Großer Wert ⇒ Schrittverlust/Schlupf/Fehlkalibrierung.
+    Nur sinnvoll bei vollständiger Umdrehung (≥ 350°)."""
     if cKDTree is None or not frames:
         return None
+    if scan_angle < 350:
+        return None  # Kein räumlicher Überlapp bei Teilscans
     z = np.array([fr["z_angle"] for fr in frames], dtype=float)
     start_sel = [fr for fr, zz in zip(frames, z) if 0.0 <= zz <= overlap_deg]
     # Überlappung am Ende: derselbe Raumbereich, ~180° weitergedreht

--- a/backend/storage.py
+++ b/backend/storage.py
@@ -117,6 +117,22 @@ class ScanStore:
             fh.write(arr.tobytes())
 
     # ------------------------------------------------------------------
+    def delete_scan(self, scan_id: str) -> None:
+        import shutil
+        d = self.scan_dir(scan_id)
+        if d.exists() and d.parent.resolve() == self.base.resolve():
+            shutil.rmtree(d)
+
+    def update_annotation(self, scan_id: str, text: str) -> None:
+        meta_path = self.scan_dir(scan_id) / "meta.json"
+        if meta_path.exists():
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        else:
+            meta = {"id": scan_id}
+        meta["annotation"] = text
+        meta_path.write_text(json.dumps(meta, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    # ------------------------------------------------------------------
     def zip_bytes(self, scan_id: str) -> bytes:
         d = self.scan_dir(scan_id)
         buf = io.BytesIO()

--- a/config.json
+++ b/config.json
@@ -29,8 +29,8 @@
   "MODE_B_CONTINUOUS": {
     "SCAN_ANGLE": 184.0,
     "OVERLAP_DEG": 4.0,
-    "SPEED_DPS": 6.0,
-    "ACCEL_DPS2": 30.0,
+    "SPEED_DPS": 327.0,
+    "ACCEL_DPS2": 1635.0,
     "PWM_CHANNEL": 1
   },
 

--- a/docs/images/koordinatensystem_3d.svg
+++ b/docs/images/koordinatensystem_3d.svg
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 600" width="920" height="600"
+     font-family="'Segoe UI', system-ui, sans-serif" font-size="13">
+  <!-- PiLiDAR 2.0 – Koordinatensystem & Sensor-Ausrichtung (3D-Übersicht) -->
+
+  <!-- Hintergrund -->
+  <rect width="920" height="600" fill="#f9fafb" rx="8"/>
+
+  <!-- Titel -->
+  <text x="460" y="32" text-anchor="middle" font-size="16" font-weight="700" fill="#111">
+    PiLiDAR 2.0 — Koordinatensystem &amp; Sensor-Ausrichtung (Isometrische Übersicht)
+  </text>
+  <text x="460" y="52" text-anchor="middle" font-size="12" fill="#555">
+    Rechtshändiges System X×Y=Z · Winkel in Grad · Längen in mm (schematisch, nicht maßstäblich)
+  </text>
+
+  <!-- ═══════════════════════════════════════════════════════════
+       LINKES BILD: Isometrische 3D-Ansicht
+       Ursprung O bei (280, 340) im SVG
+       Isometrisch: X → rechts-unten (+30°), Y → links-unten (+150°), Z → oben
+  ════════════════════════════════════════════════════════════════ -->
+  <g transform="translate(280,340)">
+    <!-- Isometrische Richtungsvektoren (px pro 100 mm):
+         X: (cos(-30°)·120, sin(-30°)·120) = (104, -60) → rechts-unten
+         Y: (cos(210°)·120, sin(210°)·120) = (-104, -60) → links-unten  [jetzt: rechts um 30° nach unten angepasst]
+         Z: (0, -130) → oben
+    -->
+
+    <!-- Hilfsraster (leicht grau) - Bodenebene Y-X -->
+    <g stroke="#d0d7de" stroke-width="0.5" opacity="0.6">
+      <!-- X-Richtungslinien bei Y-Offset -->
+      <line x1="-104" y1="60"  x2="0"    y2="0"/>
+      <line x1="-104" y1="60"  x2="104"  y2="120"/><!-- korrigiert -->
+      <!-- Y-Richtungslinien bei X-Offset -->
+    </g>
+
+    <!-- Boden-Parallelogramm (X-Y-Ebene bei Z=0) -->
+    <polygon points="0,0 104,60 0,120 -104,60"
+             fill="#e8f4fd" stroke="#93c5e8" stroke-width="1" opacity="0.6"/>
+    <text x="-45" y="95" font-size="10" fill="#5a9bc2" text-anchor="middle">X-Y-Ebene (Z=0)</text>
+
+    <!-- Rotation z_angle: Bogen auf Bodenebene -->
+    <path d="M 50,29 A 58,33 0 0 1 0,0" fill="none" stroke="#16a34a" stroke-width="1.5" stroke-dasharray="4,2"/>
+    <polygon points="0,-4 -5,4 5,4" transform="translate(1,1) rotate(-20)" fill="#16a34a"/>
+    <text x="62" y="20" font-size="11" fill="#16a34a" font-weight="600">z_angle</text>
+    <text x="62" y="33" font-size="10" fill="#16a34a">(Drehung ⊙ Z)</text>
+
+    <!-- Drehachse Z (vertikal) - gestrichelt unterhalb Ursprung -->
+    <line x1="0" y1="20" x2="0" y2="60" stroke="#888" stroke-width="1" stroke-dasharray="3,3"/>
+
+    <!-- === ACHSEN === -->
+
+    <!-- Z-Achse: gerade nach oben -->
+    <line x1="0" y1="0" x2="0" y2="-170" stroke="#dc2626" stroke-width="2.5"/>
+    <polygon points="0,-178 -5,-163 5,-163" fill="#dc2626"/>
+    <text x="8" y="-175" font-size="14" font-weight="700" fill="#dc2626">Z</text>
+    <text x="8" y="-160" font-size="10" fill="#dc2626">(oben)</text>
+
+    <!-- X-Achse: rechts-unten (isometrisch 30°) -->
+    <line x1="0" y1="0" x2="156" y2="90" stroke="#2563eb" stroke-width="2.5"/>
+    <polygon points="0,0 -7,-3 -4,6" transform="translate(156,90) rotate(30)" fill="#2563eb"/>
+    <text x="164" y="95" font-size="14" font-weight="700" fill="#2563eb">X</text>
+    <text x="164" y="110" font-size="10" fill="#2563eb">(α=0)</text>
+
+    <!-- Y-Achse: links-unten (isometrisch 150°) -->
+    <line x1="0" y1="0" x2="-156" y2="90" stroke="#9333ea" stroke-width="2.5"/>
+    <polygon points="0,0 7,-3 4,6" transform="translate(-156,90) rotate(-30)" fill="#9333ea"/>
+    <text x="-180" y="95" font-size="14" font-weight="700" fill="#9333ea">Y</text>
+    <text x="-185" y="110" font-size="10" fill="#9333ea">(Spinachse)</text>
+
+    <!-- Ursprung O -->
+    <circle cx="0" cy="0" r="4" fill="#111"/>
+    <text x="8" y="-6" font-size="11" fill="#111">O (Datum)</text>
+
+    <!-- Drehachse Z (vertikal, verlängert nach unten) -->
+    <line x1="0" y1="0" x2="0" y2="80" stroke="#888" stroke-width="1.5" stroke-dasharray="5,3"/>
+    <text x="6" y="72" font-size="10" fill="#888">Drehachse</text>
+
+    <!-- Sensor-Position S: MODEL_Y=-37.5mm, MODEL_Z=-41.9mm
+         In iso: Y-Anteil → links-unten(-37.5/100*104, -37.5/100*60) = (-39, -22.5) [negativ Y → positiv in Zeichenrichtung]
+         Z-Anteil → nach unten(0, 41.9/100*130) = (0, +54)
+         Gesamtposition: (-39, -22.5+54) = (-39, +31.5) ... Y negativ → gegenrichtung
+         MODEL_Y = -37.5 → Richtung -Y → (+37.5/100*104, +37.5/100*60) = (+39, +22.5)
+         MODEL_Z = -41.9 → Richtung -Z → (0, +41.9/130*1) = (0, +54)
+         Sensor bei iso: (+39, +22.5+54) = (+39, +76.5)  -->
+    <g transform="translate(39, 76)">
+      <!-- Hilfslinie von Achse zu Sensor -->
+      <line x1="-39" y1="-76" x2="0" y2="0" stroke="#f59e0b" stroke-width="1" stroke-dasharray="4,2"/>
+      <!-- MODEL_Y Pfeil -->
+      <line x1="-39" y1="-76" x2="0" y2="-54" stroke="#9333ea" stroke-width="1.5" stroke-dasharray="5,2"/>
+      <text x="-5" y="-62" font-size="10" fill="#9333ea" text-anchor="end">MODEL_Y=−37.5 mm</text>
+      <!-- MODEL_Z Pfeil -->
+      <line x1="0" y1="-54" x2="0" y2="0" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="5,2"/>
+      <text x="5" y="-25" font-size="10" fill="#dc2626">MODEL_Z=−41.9 mm</text>
+      <!-- Sensor S -->
+      <circle cx="0" cy="0" r="7" fill="#dc2626" opacity="0.9"/>
+      <circle cx="0" cy="0" r="3" fill="white"/>
+      <text x="14" y="4" font-size="12" font-weight="700" fill="#dc2626">S</text>
+      <text x="14" y="17" font-size="10" fill="#555">(LiDAR-Optikzentrum)</text>
+    </g>
+
+  </g><!-- /isometrische Gruppe -->
+
+  <!-- ═══════════════════════════════════════════════════════════
+       RECHTES BILD: Scan-Ebene X-Z (Blick entlang +Y) – Winkel-Null
+  ════════════════════════════════════════════════════════════════ -->
+  <g transform="translate(680,340)">
+
+    <!-- Achsen X und Z -->
+    <line x1="-160" y1="0" x2="160" y2="0" stroke="#2563eb" stroke-width="2"/>
+    <polygon points="160,0 150,-5 150,5" fill="#2563eb"/>
+    <text x="168" y="5" font-size="14" font-weight="700" fill="#2563eb">X</text>
+
+    <line x1="0" y1="150" x2="0" y2="-180" stroke="#dc2626" stroke-width="2"/>
+    <polygon points="0,-180 -5,-170 5,-170" fill="#dc2626"/>
+    <text x="8" y="-178" font-size="14" font-weight="700" fill="#dc2626">Z</text>
+
+    <!-- Y aus Ebene heraus -->
+    <circle cx="0" cy="0" r="7" fill="none" stroke="#9333ea" stroke-width="2"/>
+    <circle cx="0" cy="0" r="2" fill="#9333ea"/>
+    <text x="-30" y="-12" font-size="11" fill="#9333ea">⊙ Y</text>
+    <text x="-30" y="-25" font-size="10" fill="#9333ea">(aus Ebene)</text>
+
+    <!-- Sensor S im Mittelpunkt -->
+    <circle cx="0" cy="0" r="6" fill="#dc2626" opacity="0.9"/>
+    <circle cx="0" cy="0" r="2.5" fill="white"/>
+    <text x="-20" y="20" font-size="11" font-weight="700" fill="#dc2626">S (Sensor)</text>
+
+    <!-- Messstrahl bei α=0 (nominell): Richtung +X -->
+    <line x1="0" y1="0" x2="140" y2="0" stroke="#2563eb" stroke-width="1.5" stroke-dasharray="6,3"/>
+    <text x="100" y="-8" font-size="11" fill="#2563eb">α = 0°</text>
+    <text x="100" y="-22" font-size="10" fill="#2563eb">(nominell)</text>
+
+    <!-- Messstrahl bei tatsächlicher Null (angle_offset = -1.05°) -->
+    <!-- cos(-1.05°)=0.9998, sin(-1.05°)=-0.0183 → fast gleich, kleine Abweichung nach unten -->
+    <!-- Zur Lesbarkeit stark übertrieben dargestellt: 15° -->
+    <line x1="0" y1="0" x2="133" y2="35" stroke="#16a34a" stroke-width="2"/>
+    <polygon points="0,0 -4,6 5,4" transform="translate(133,35) rotate(15)" fill="#16a34a"/>
+    <text x="115" y="55" font-size="11" fill="#16a34a">α = 0° (tatsächlich)</text>
+    <text x="115" y="68" font-size="10" fill="#16a34a">nach angle_offset</text>
+
+    <!-- Bogen für angle_offset -->
+    <path d="M 60,0 A 60,60 0 0 1 57.9,15.6" fill="none" stroke="#f59e0b" stroke-width="1.5"/>
+    <text x="68" y="12" font-size="10" fill="#f59e0b">angle_offset</text>
+    <text x="68" y="24" font-size="10" fill="#f59e0b">= −1.05°</text>
+    <text x="68" y="36" font-size="9" fill="#888">(übertrieben dargest.)</text>
+
+    <!-- Beispiel-Messpunkt P -->
+    <line x1="0" y1="0" x2="105" y2="-115" stroke="#555" stroke-width="1.5"/>
+    <circle cx="105" cy="-115" r="5" fill="#555"/>
+    <text x="115" y="-118" font-size="11" fill="#333">P (Messpunkt)</text>
+    <!-- Bogen für Messwinkel -->
+    <path d="M 50,0 A 50,50 0 0 0 35.3,-38.3" fill="none" stroke="#555" stroke-width="1.2" stroke-dasharray="3,2"/>
+    <text x="55" y="-25" font-size="10" fill="#555">α (Messwinkel)</text>
+    <text x="55" y="-38" font-size="9" fill="#888">0°–360°, CCW</text>
+
+    <!-- Beschriftung Scan-Ebene -->
+    <text x="-155" y="-165" font-size="11" font-weight="600" fill="#333">Scan-Ebene X-Z</text>
+    <text x="-155" y="-150" font-size="10" fill="#666">(Blick entlang +Y)</text>
+
+  </g><!-- /scan-plane Gruppe -->
+
+  <!-- ═══════════════════════════════════════════════════════════
+       LEGENDE
+  ════════════════════════════════════════════════════════════════ -->
+  <g transform="translate(30, 450)">
+    <rect width="250" height="135" rx="6" fill="#f0f4f8" stroke="#d0d7de"/>
+    <text x="12" y="20" font-size="12" font-weight="700" fill="#111">Legende</text>
+
+    <circle cx="22" cy="38" r="5" fill="#dc2626"/>
+    <text x="34" y="43" font-size="11" fill="#333">Z — Vertikale (oben ↑)</text>
+
+    <circle cx="22" cy="58" r="5" fill="#2563eb"/>
+    <text x="34" y="63" font-size="11" fill="#333">X — Horizontal, α=0 Richtung</text>
+
+    <circle cx="22" cy="78" r="5" fill="#9333ea"/>
+    <text x="34" y="83" font-size="11" fill="#333">Y — Spinachse (Drehung)</text>
+
+    <circle cx="22" cy="98" r="5" fill="#dc2626" opacity="0.9"/>
+    <circle cx="22" cy="98" r="2" fill="white"/>
+    <text x="34" y="103" font-size="11" fill="#333">S — LiDAR-Optikzentrum</text>
+
+    <line x1="14" y1="118" x2="30" y2="118" stroke="#16a34a" stroke-width="2"/>
+    <text x="34" y="123" font-size="11" fill="#333">z_angle — Plattformdrehung</text>
+  </g>
+
+  <!-- Hinweisbox STL27L -->
+  <g transform="translate(300, 450)">
+    <rect width="300" height="135" rx="6" fill="#fefce8" stroke="#fde68a"/>
+    <text x="12" y="20" font-size="12" font-weight="700" fill="#78350f">STL27L — Sensor-Null</text>
+    <text x="12" y="40" font-size="11" fill="#92400e">Winkel α = 0° zeigt in Richtung +X,</text>
+    <text x="12" y="56" font-size="11" fill="#92400e">wenn z_angle = 0° (Startposition).</text>
+    <text x="12" y="76" font-size="11" fill="#92400e">Winkel wächst gegen den Uhrzeigersinn</text>
+    <text x="12" y="92" font-size="11" fill="#92400e">in der X-Z-Scan-Ebene (CCW).</text>
+    <text x="12" y="112" font-size="11" fill="#b45309">angle_offset korrigiert Montage-</text>
+    <text x="12" y="126" font-size="11" fill="#b45309">kippung (Y-Drehung in Scan-Ebene).</text>
+  </g>
+
+  <!-- Offsets-Erklärung -->
+  <g transform="translate(620, 450)">
+    <rect width="270" height="135" rx="6" fill="#f0fdf4" stroke="#86efac"/>
+    <text x="12" y="20" font-size="12" font-weight="700" fill="#14532d">Offsets (config.json)</text>
+    <text x="12" y="40" font-size="11" fill="#166534">MODEL_Y = −37.5 mm</text>
+    <text x="12" y="55" font-size="10" fill="#4ade80">Sensor-Abstand von Drehachse (−Y)</text>
+    <text x="12" y="75" font-size="11" fill="#166534">MODEL_Z = −41.9 mm</text>
+    <text x="12" y="90" font-size="10" fill="#4ade80">Sensor-Höhe unter Datum-Punkt (−Z)</text>
+    <text x="12" y="110" font-size="11" fill="#166534">angle_offset = −1.05°</text>
+    <text x="12" y="125" font-size="10" fill="#4ade80">Korrigiert Sensor-Kippung um Y-Achse</text>
+  </g>
+
+  <!-- Trennlinie zwischen den Ansichten -->
+  <line x1="460" y1="65" x2="460" y2="430" stroke="#d0d7de" stroke-width="1" stroke-dasharray="6,3"/>
+  <text x="280" y="80" text-anchor="middle" font-size="11" fill="#888">Ansicht A — Isometrisch (alle 3 Achsen)</text>
+  <text x="680" y="80" text-anchor="middle" font-size="11" fill="#888">Ansicht B — Scan-Ebene X-Z (Blick entlang +Y)</text>
+
+</svg>

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -107,3 +107,49 @@ button:disabled { opacity: .45; cursor: not-allowed; }
 #scanList a { color: var(--accent2); text-decoration: none; }
 #scanList .dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 5px; }
 .dot.ok { background: var(--accent); } .dot.warn { background: var(--warn); } .dot.error { background: var(--danger); }
+.dot.dot-off { background: #3a4554; }
+
+/* System-Stats */
+.sys-stats { gap: 5px; }
+.sys-stats strong { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: .4px; }
+
+/* LiDAR-Health */
+.health-row { display: flex; align-items: center; gap: 6px; }
+.health-row .dot { flex-shrink: 0; }
+
+/* Scan-Anmerkung */
+.ann-row {
+  display: flex;
+  gap: 4px;
+  margin-top: 5px;
+}
+.ann-input {
+  flex: 1;
+  background: var(--panel);
+  border: 1px solid #2f3845;
+  color: var(--fg);
+  border-radius: 5px;
+  padding: 3px 7px;
+  font-size: 11px;
+}
+.ann-input:focus { outline: none; border-color: var(--accent2); }
+.ann-save {
+  padding: 2px 8px;
+  font-size: 12px;
+  background: var(--panel2);
+  border: 1px solid #2f3845;
+  border-radius: 5px;
+  cursor: pointer;
+  color: var(--accent);
+}
+.ann-save:hover { border-color: var(--accent); }
+.btn-del {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--muted);
+  font-size: 13px;
+  padding: 0 2px;
+  line-height: 1;
+}
+.btn-del:hover { color: var(--danger); }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -54,6 +54,21 @@
         <div>Pakete/s: <b id="stRate">0</b></div>
         <div>CRC-Fehler: <b id="stCrc">0</b>%</div>
         <div>Punkte: <b id="stPts">0</b></div>
+        <div>Opt. Geschw.: <b id="stOptSpeed">–</b> °/s</div>
+        <div class="health-row">LiDAR: <span id="lidarHealth" class="dot dot-off"></span> <b id="lidarHealthTxt">–</b></div>
+      </div>
+
+      <div class="group stats sys-stats">
+        <strong>System</strong>
+        <div>CPU: <b id="stCpu">–</b> %</div>
+        <div>RAM: <b id="stRam">–</b> %</div>
+        <div id="stNet">Netzwerk: –</div>
+      </div>
+
+      <div class="group">
+        <strong>System-Steuerung</strong>
+        <button id="btnReboot" class="secondary">&#8635; Neustart</button>
+        <button id="btnPoweroff" class="danger">&#9210; Ausschalten</button>
       </div>
     </section>
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -73,6 +73,7 @@ document.querySelectorAll('input[name=view]').forEach(r => r.onchange = () => {
   viewMode = document.querySelector('input[name=view]:checked').value;
   $('view2d').classList.toggle('hidden', viewMode !== '2d');
   $('view3d').classList.toggle('hidden', viewMode !== '3d');
+  if (viewMode === '3d') v3d._resize();
 });
 
 function clearView() {
@@ -82,6 +83,36 @@ function clearView() {
 $('btnClear').onclick = clearView;
 $('btnPly').onclick = () => worker.postMessage({ type: 'export' });
 
+// --- System-Steuerung -------------------------------------------------
+$('btnReboot').onclick = () => {
+  if (confirm('Raspberry Pi wirklich neu starten?'))
+    api('/api/system/reboot', { method: 'POST' });
+};
+$('btnPoweroff').onclick = () => {
+  if (confirm('Raspberry Pi wirklich ausschalten?'))
+    api('/api/system/poweroff', { method: 'POST' });
+};
+
+// --- LiDAR-Health-Indikator -------------------------------------------
+function updateLidarHealth(s) {
+  const dot = $('lidarHealth');
+  const txt = $('lidarHealthTxt');
+  const rate = s.stats.packet_rate;
+  const crc  = s.stats.crc_error_rate;
+  dot.className = 'dot';
+  if (!s.lidar_running) {
+    dot.classList.add('dot-off'); txt.textContent = 'aus';
+  } else if (crc > 0.02) {
+    dot.classList.add('error'); txt.textContent = `CRC-Fehler ${(crc * 100).toFixed(1)} %`;
+  } else if (rate >= 1500) {
+    dot.classList.add('ok'); txt.textContent = `OK (${Math.round(rate)} pkt/s)`;
+  } else if (rate >= 1000) {
+    dot.classList.add('warn'); txt.textContent = `Degradiert (${Math.round(rate)} pkt/s)`;
+  } else {
+    dot.classList.add('error'); txt.textContent = `Fehler (${Math.round(rate)} pkt/s)`;
+  }
+}
+
 // --- Status-Polling ---------------------------------------------------
 async function poll() {
   try {
@@ -89,10 +120,30 @@ async function poll() {
     const b = $('state'); b.textContent = s.state;
     b.className = 'badge ' + (s.state === 'idle' ? 'ok' : s.state === 'scanning' ? 'warn' : '');
     $('stAngle').textContent = s.angle;
-    $('stRate').textContent = Math.round(s.stats.packet_rate);
+    $('stRate').textContent = s.lidar_running ? Math.round(s.stats.packet_rate) : 0;
     $('stCrc').textContent = (s.stats.crc_error_rate * 100).toFixed(2);
+    if (s.stats.last_speed_dps > 0)
+      $('stOptSpeed').textContent = (s.stats.last_speed_dps / 11).toFixed(1);
+    updateLidarHealth(s);
   } catch (e) { /* offline */ }
+  try {
+    const sys = await (await api('/api/system/stats')).json();
+    if (sys.available) {
+      $('stCpu').textContent = sys.cpu_percent.toFixed(1);
+      $('stRam').textContent = sys.ram_percent.toFixed(1);
+      const eth = sys.net.eth0 || sys.net.end0 || sys.net.wlan0 || {};
+      const bt  = sys.net.bnep0 || {};
+      const parts = [];
+      if (eth.rx_bps !== undefined)
+        parts.push(`LAN ↓${_kb(eth.rx_bps)} ↑${_kb(eth.tx_bps)}`);
+      if (bt.rx_bps !== undefined && (bt.rx_bps + bt.tx_bps) > 0)
+        parts.push(`BT ↓${_kb(bt.rx_bps)} ↑${_kb(bt.tx_bps)}`);
+      $('stNet').textContent = parts.length ? parts.join(' · ') : 'Netzwerk: –';
+    }
+  } catch (e) { /* psutil nicht verfügbar */ }
 }
+function _kb(bps) { return bps < 1024 ? `${bps} B/s` : `${(bps/1024).toFixed(0)} KB/s`; }
+
 setInterval(poll, 700); poll();
 
 // --- Scan-Liste -------------------------------------------------------
@@ -100,13 +151,40 @@ async function refreshScans() {
   const scans = await (await api('/api/scans')).json();
   const ul = $('scanList'); ul.innerHTML = '';
   for (const s of scans) {
-    const qa = (s.qa && s.qa.status) || '';
-    const li = document.createElement('li');
-    li.innerHTML = `<div class="row"><span><span class="dot ${qa}"></span><b>${s.id}</b></span>
-      <a href="/api/scans/${s.id}/download">ZIP</a></div>
-      <div style="color:#7d8794">Modus ${s.mode || '?'} · ${s.n_points || 0} Pkt · QA ${qa || '–'}</div>`;
+    const qa  = (s.qa && s.qa.status) || '';
+    const ann = (s.annotation || '').replace(/"/g, '&quot;');
+    const li  = document.createElement('li');
+    li.innerHTML = `
+      <div class="row">
+        <span><span class="dot ${qa}"></span><b>${s.id}</b></span>
+        <span style="display:flex;gap:6px;align-items:center">
+          <a href="/api/scans/${s.id}/download">ZIP</a>
+          <button class="btn-del" data-id="${s.id}">&#128465;</button>
+        </span>
+      </div>
+      <div style="color:#7d8794;margin-top:2px">Modus ${s.mode || '?'} &middot; ${(s.n_points || 0).toLocaleString('de-DE')} Pkt &middot; QA ${qa || '–'}</div>
+      <div class="ann-row">
+        <input class="ann-input" type="text" placeholder="Anmerkung…" value="${ann}" />
+        <button class="ann-save" data-id="${s.id}">&#10003;</button>
+      </div>`;
     ul.appendChild(li);
   }
+  ul.querySelectorAll('.btn-del').forEach(btn => {
+    btn.onclick = async () => {
+      if (!confirm(`Scan "${btn.dataset.id}" wirklich löschen?`)) return;
+      await api(`/api/scans/${btn.dataset.id}`, { method: 'DELETE' });
+      refreshScans();
+    };
+  });
+  ul.querySelectorAll('.ann-save').forEach(btn => {
+    btn.onclick = async () => {
+      const input = btn.closest('li').querySelector('.ann-input');
+      await api(`/api/scans/${btn.dataset.id}/annotation`, {
+        method: 'POST',
+        body: JSON.stringify({ text: input.value }),
+      });
+    };
+  });
 }
 $('btnRefresh').onclick = refreshScans;
 refreshScans();

--- a/frontend/js/viewer3d.js
+++ b/frontend/js/viewer3d.js
@@ -39,6 +39,7 @@ class Viewer3D {
   constructor(canvas) {
     this.canvas = canvas;
     const gl = this.gl = canvas.getContext('webgl', { antialias: true });
+    if (!gl) { console.error('WebGL nicht verfügbar'); return; }
     this.prog = this._program(VERT, FRAG);
     this.aPos = gl.getAttribLocation(this.prog, 'aPos');
     this.aInt = gl.getAttribLocation(this.prog, 'aInt');
@@ -114,6 +115,7 @@ class Viewer3D {
   }
 
   _loop() {
+    if (!this.gl) return;
     this._flush();
     const gl = this.gl, W = this.canvas.width, H = this.canvas.height;
     gl.viewport(0, 0, W, H); gl.clearColor(0.02, 0.03, 0.04, 1);

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ uvicorn[standard]>=0.29
 pyserial>=3.5
 numpy>=1.24
 scipy>=1.10
+psutil>=5.9
 # Hardware (nur auf dem Raspberry Pi nötig):
 rpi-lgpio>=0.6 ; platform_machine == "aarch64"
 rpi-hardware-pwm>=0.2.2 ; platform_machine == "aarch64"


### PR DESCRIPTION
## Zusammenfassung

### Bugfixes
- **3D-Ansicht**: `_resize()` wird nach Umschalten auf 3D aufgerufen (Canvas war beim Start versteckt → 0×0 px → NaN in Perspektivmatrix). Zusätzlich WebGL-Null-Guard ergänzt.
- **QA-Fehler**: Loop-Closure-Residuum wird bei Scans < 350° nicht mehr berechnet — ein 184°-Scan hat keine räumliche Überlappung, was fälschlich immer „error" auslöste.
- **Pakete/s sinkt**: `LidarStats.freeze()` friert die Rate beim Stopp ein, so dass sie nach der Kalibrierung nicht mehr gegen 0 sinkt.
- **Mode A**: `MAX_PACKAGES` wird jetzt tatsächlich abgewartet (bisher wurde nur `SCAN_DELAY` geschlafen — Original-Verhalten wiederhergestellt).

### Neue Features
- **System-Stats im Dashboard**: CPU %, RAM %, LAN/BT-Bandbreite via `psutil` (`/api/system/stats`, alle 700 ms gepollt)
- **LiDAR-Gesundheitsindikator**: Ampel grün/gelb/rot basierend auf Paketrate und CRC-Fehlerrate
- **Optimale Mode-B-Geschwindigkeit**: Info-Anzeige im Dashboard (`last_speed_dps / 11`)
- **Neustart / Ausschalten**: Buttons im Dashboard mit Bestätigungsdialog (`/api/system/reboot`, `/api/system/poweroff`)
- **Scan löschen**: Löschen-Button pro Scan mit Bestätigung (`DELETE /api/scans/{id}`)
- **Scan-Anmerkung**: Textfeld + Speichern pro Scan (`POST /api/scans/{id}/annotation`)

### Konfiguration
- `MODE_B_CONTINUOUS.SPEED_DPS`: 6 → **327 °/s** für gleichmäßigen horizontalen/vertikalen Punktabstand
  - Formel: `SPEED_DPS = LiDAR_Spiegelgeschwindigkeit / 11` (bei STL27L ~3600 °/s → 327 °/s)
  - ⚠️ Auf echter Hardware verifizieren — ggf. reduzieren falls Schritte verloren gehen
- `ACCEL_DPS2`: 30 → **1635** (proportional skaliert, gleiche Rampzeit ~0.2 s)
- `psutil>=5.9` in `requirements.txt` ergänzt

### Dokumentation
- Neue Datei `docs/images/koordinatensystem_3d.svg`: Isometrische 3D-Ansicht mit **allen 3 Achsen gleichzeitig** (+X, +Y, +Z), Sensor-Position, MODEL_Y/MODEL_Z-Offsets und Winkel-α=0-Beschriftung

## Testplan
- [ ] Mock-Modus starten: `PILIDAR_MOCK=1 python -m backend.app`
- [ ] 3D-Ansicht: Radiobutton auf „3D" → Punktwolke sichtbar
- [ ] QA: Scan in Mode B → Ergebnis „ok" statt „error"
- [ ] Pakete/s: 2D-Live starten, stoppen → Rate bleibt stabil
- [ ] CPU/RAM-Anzeige erscheint im Dashboard
- [ ] Poweroff/Reboot: Buttons erscheinen, Bestätigungsdialog vorhanden
- [ ] Mode A: Scan läuft durch (wartet auf Pakete pro Schritt)
- [ ] LiDAR-Health: Ampel wechselt Farbe bei Statusänderung
- [ ] Scan löschen → Liste aktualisiert sich
- [ ] Anmerkung eingeben + speichern → nach Refresh noch vorhanden

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuqgSdThFskz1TgGvBdD2d

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuqgSdThFskz1TgGvBdD2d)_