### PR TITLE
Fix: Mode-B-Geschwindigkeit für gleichen Punktabstand (327 → 1.87 °/s)

### DIFF
--- a/config.json
+++ b/config.json
@@ -29,8 +29,8 @@
   "MODE_B_CONTINUOUS": {
     "SCAN_ANGLE": 184.0,
     "OVERLAP_DEG": 4.0,
-    "SPEED_DPS": 327.0,
-    "ACCEL_DPS2": 1635.0,
+    "SPEED_DPS": 1.87,
+    "ACCEL_DPS2": 10.0,
     "PWM_CHANNEL": 1
   },
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -11,6 +11,7 @@ const worker = new Worker('js/scan.worker.js');
 let ws = null;
 let viewMode = '2d';
 let totalPoints = 0;
+let lidarResDeg = 0;   // vertikale Winkelauflösung [°], live aus Frames gemessen
 
 v2d.start();
 
@@ -35,6 +36,11 @@ function connectWS() {
     if (m.type === 'init') {
       worker.postMessage({ type: 'init', ...m });
     } else if (m.type === 'frame') {
+      // Winkelauflösung aus benachbarten Punkten eines Pakets messen (Wrap ausschließen)
+      if (m.a && m.a.length >= 2) {
+        const step = Math.abs(m.a[1] - m.a[0]);
+        if (step > 0 && step < 5) lidarResDeg = step;
+      }
       if (viewMode === '2d') v2d.addFrame(m.a, m.d);
       worker.postMessage({ type: 'frame', a: m.a, d: m.d, i: m.i, z: m.z });
     }
@@ -122,8 +128,12 @@ async function poll() {
     $('stAngle').textContent = s.angle;
     $('stRate').textContent = s.lidar_running ? Math.round(s.stats.packet_rate) : 0;
     $('stCrc').textContent = (s.stats.crc_error_rate * 100).toFixed(2);
-    if (s.stats.last_speed_dps > 0)
-      $('stOptSpeed').textContent = (s.stats.last_speed_dps / 11).toFixed(1);
+    // Optimale Plattform-Geschwindigkeit für gleichen H/V-Punktabstand:
+    //   SPEED_DPS = Auflösung[°] × Umdrehungsfrequenz[Hz] = res × (spiegel_dps / 360)
+    if (s.stats.last_speed_dps > 0 && lidarResDeg > 0) {
+      const freqHz = s.stats.last_speed_dps / 360;
+      $('stOptSpeed').textContent = (lidarResDeg * freqHz).toFixed(2);
+    }
     updateLidarHealth(s);
   } catch (e) { /* offline */ }
   try {


### PR DESCRIPTION
## Korrektur eines Rechenfehlers aus PR #31

Der in PR #31 gesetzte Wert `SPEED_DPS = 327 °/s` war **falsch**. Korrekter Wert: **1.87 °/s**.

### Fehleranalyse
Der horizontale Punktabstand entsteht durch die Plattformdrehung **pro voller LiDAR-Umdrehung** — eine bestimmte vertikale Linie wird nur **einmal je Umdrehung** (alle 0,1 s bei 10 Hz) erneut gemessen. Er entsteht **nicht** pro Datenpaket.

**Falsch (PR #31):** `SPEED_DPS = Spiegelgeschw. / 11 = 3600 / 11 = 327 °/s`
→ teilte durch die Punkte-pro-Paket; physikalisch bedeutungslos für den horizontalen Abstand. Ergäbe **32,7° Plattformdrehung pro Umdrehung** → extrem grober Scan.

**Richtig:** 
```
SPEED_DPS = Auflösung[°] × Umdrehungsfrequenz[Hz]
          = 0,187° × 10 Hz
          = 1,87 °/s
```
Gegenprobe: 1,87 °/s ÷ 10 Hz = 0,187° horizontaler Schritt pro Umdrehung = vertikale Auflösung ✓

### Änderungen
- `config.json`: `SPEED_DPS` 327 → **1.87**, `ACCEL_DPS2` 1635 → **10.0**
- `frontend/js/app.js`: Dashboard-Anzeige „Opt. Geschw." nutzt jetzt die **live aus den Frames gemessene** Winkelauflösung × Umdrehungsfrequenz (`res × spiegel_dps/360`) statt des falschen Faktors `/11`. Robust gegen unterschiedliche LiDAR-Konfigurationen.

### Auswirkung
- Scan-Dauer 184° bei 1,87 °/s ≈ **98 s** (~1,6 min) — langsamer als vorher, aber das ist der korrekte Wert für *exakt gleichen* H/V-Punktabstand.
- Wer schneller scannen will, kann `SPEED_DPS` erhöhen → horizontaler Abstand wird dann gröber als der vertikale (kein Fehler, nur andere Dichte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuqgSdThFskz1TgGvBdD2d

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuqgSdThFskz1TgGvBdD2d)_