### PR TITLE
LiDAR-Spiegelsteuerung, 3D-Achsen, Scan-Anzeige und 2D/3D-Fix

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -94,6 +94,15 @@ async def api_scans():
     return controller.store.list_scans()
 
 
+@app.get("/api/scans/{scan_id}/pointcloud")
+async def api_scan_pointcloud(scan_id: str):
+    """Gespeicherte Punktwolke für die 3D-Anzeige (flache xyz/inten-Listen)."""
+    data = await asyncio.to_thread(controller.store.load_pointcloud, scan_id)
+    if not data.get("total"):
+        return JSONResponse(status_code=404, content={"error": "keine Punktwolke"})
+    return data
+
+
 @app.get("/api/scans/{scan_id}/download")
 async def api_scan_download(scan_id: str):
     data = controller.store.zip_bytes(scan_id)

--- a/backend/controller.py
+++ b/backend/controller.py
@@ -134,8 +134,9 @@ class ScanController:
     def start_scan(self, mode: str = "B", name: str = "") -> str:
         if self.state not in (STATE_IDLE, STATE_LIDAR_ONLY):
             raise RuntimeError(f"Beschäftigt: {self.state}")
-        if self.state == STATE_LIDAR_ONLY:
-            self.lidar.stop()
+        # Den LiDAR-Spiegel beim Übergang aus 2D-Live NICHT aus- und wieder
+        # einschalten – er soll durchgehend laufen. lidar.start() in _run_scan
+        # ist idempotent (No-op, falls bereits aktiv).
         scan_id = datetime.now().strftime("%y%m%d-%H%M%S")
         if name:
             scan_id += "_" + "".join(c for c in name if c.isalnum() or c in "-_")

--- a/backend/hardware/lidar.py
+++ b/backend/hardware/lidar.py
@@ -121,6 +121,7 @@ class LidarReader:
         self._ser = None
         self._thread: Optional[threading.Thread] = None
         self._running = threading.Event()
+        self._motor_on = False        # verfolgt den Spiegelmotor-Zustand (idempotent)
         self.stats = LidarStats()
 
     # ------------------------------------------------------------------
@@ -141,20 +142,46 @@ class LidarReader:
                 self._ser = None
 
     # ------------------------------------------------------------------
+    def _set_motor(self, on: bool) -> None:
+        """Spiegelmotor schalten (Waveshare STL27L): b'1' = an, b'0' = aus.
+
+        Idempotent: sendet den Befehl nur bei tatsächlichem Zustandswechsel, damit
+        der Spiegel nicht versehentlich mehrfach hoch-/runtergefahren wird. Die
+        ASCII-Zeichen "1"/"0" gehen über denselben Serial-Port (921600 Baud). Im
+        Mock-Modus oder bei Serial-Fehlern wird still ignoriert.
+        """
+        if on == self._motor_on:
+            return
+        ser = self._ser
+        if ser is not None:
+            try:
+                if getattr(ser, "is_open", True):
+                    ser.write(b"1" if on else b"0")
+                    ser.flush()
+            except Exception:
+                pass  # Serial-Schreibfehler nicht propagieren
+        self._motor_on = on
+
+    # ------------------------------------------------------------------
     def start(self) -> None:
+        if self._running.is_set():
+            return  # bereits aktiv – kein zweiter Reader-Thread, kein erneuter Motorbefehl
         if self._ser is None:
             self.open()
+        self._set_motor(True)  # Spiegelmotor starten
         self.stats = LidarStats()
         self._running.set()
         self._thread = threading.Thread(target=self._loop, name="LidarReader", daemon=True)
         self._thread.start()
 
     def stop(self) -> None:
-        self.stats.freeze()
-        self._running.clear()
+        if self._running.is_set():
+            self.stats.freeze()
+            self._running.clear()
         if self._thread is not None:
             self._thread.join(timeout=2.0)
             self._thread = None
+        self._set_motor(False)  # Spiegelmotor stoppen
 
     @property
     def running(self) -> bool:

--- a/backend/hardware/lidar.py
+++ b/backend/hardware/lidar.py
@@ -121,7 +121,12 @@ class LidarReader:
         self._ser = None
         self._thread: Optional[threading.Thread] = None
         self._running = threading.Event()
-        self._motor_on = False        # verfolgt den Spiegelmotor-Zustand (idempotent)
+        # Der STL27L-Spiegel dreht ab Werk, sobald er mit Strom versorgt wird
+        # (laut Waveshare-Doku stoppt erst ein "0"). Daher gilt er initial als
+        # "läuft": beim normalen Start wird KEIN "1" gesendet, der Spiegel läuft
+        # einfach durch. Ein "0" geht nur beim expliziten Stopp raus, ein "1" nur,
+        # um nach einem solchen Stopp wieder anzufahren.
+        self._motor_on = True
         self.stats = LidarStats()
 
     # ------------------------------------------------------------------
@@ -168,7 +173,8 @@ class LidarReader:
             return  # bereits aktiv – kein zweiter Reader-Thread, kein erneuter Motorbefehl
         if self._ser is None:
             self.open()
-        self._set_motor(True)  # Spiegelmotor starten
+        # No-op falls der Spiegel ohnehin läuft; sendet "1" nur nach einem Stopp.
+        self._set_motor(True)
         self.stats = LidarStats()
         self._running.set()
         self._thread = threading.Thread(target=self._loop, name="LidarReader", daemon=True)

--- a/backend/hardware/mock_serial.py
+++ b/backend/hardware/mock_serial.py
@@ -69,6 +69,13 @@ class MockLidarSerial:
         del self._buf[:n]
         return out
 
+    def write(self, data: bytes) -> int:
+        # Motor-Steuerbefehle (b"0"/b"1") werden im Mock ignoriert.
+        return len(data)
+
+    def flush(self) -> None:
+        pass
+
     def close(self):
         pass
 

--- a/backend/storage.py
+++ b/backend/storage.py
@@ -117,6 +117,50 @@ class ScanStore:
             fh.write(arr.tobytes())
 
     # ------------------------------------------------------------------
+    def load_pointcloud(self, scan_id: str) -> dict:
+        """Punktwolke eines gespeicherten Scans laden (für die 3D-Anzeige).
+
+        Liest bevorzugt die kompakte PLY-Datei (mit Intensität), fällt sonst auf
+        die XYZ-Textdatei zurück. Gibt geflachte Float-Listen zurück, kompatibel
+        mit Viewer3D.addPoints():  {"xyz": [...], "inten": [...], "total": n}.
+        """
+        d = self.scan_dir(scan_id) / "pointcloud"
+        ply = d / f"{scan_id}.ply"
+        if ply.exists():
+            return self._read_ply(ply)
+        xyz = d / f"{scan_id}.xyz"
+        if xyz.exists():
+            pts = np.loadtxt(xyz, dtype=np.float32)
+            pts = np.atleast_2d(pts)
+            n = len(pts)
+            return {"xyz": pts.reshape(-1).tolist(),
+                    "inten": [180.0] * n, "total": n}
+        return {"xyz": [], "inten": [], "total": 0}
+
+    @staticmethod
+    def _read_ply(path: Path) -> dict:
+        """Binäres PLY (siehe _write_ply) zurück in flache Listen lesen."""
+        with open(path, "rb") as fh:
+            raw = fh.read()
+        end = raw.find(b"end_header\n")
+        if end < 0:
+            return {"xyz": [], "inten": [], "total": 0}
+        header = raw[:end].decode("ascii", "ignore")
+        n = 0
+        for line in header.splitlines():
+            if line.startswith("element vertex"):
+                n = int(line.split()[-1])
+        body = raw[end + len(b"end_header\n"):]
+        dtype = np.dtype([("x", "<f4"), ("y", "<f4"), ("z", "<f4"),
+                          ("r", "u1"), ("g", "u1"), ("b", "u1")])
+        arr = np.frombuffer(body, dtype=dtype, count=n)
+        xyz = np.empty((n, 3), dtype=np.float32)
+        xyz[:, 0] = arr["x"]; xyz[:, 1] = arr["y"]; xyz[:, 2] = arr["z"]
+        return {"xyz": xyz.reshape(-1).tolist(),
+                "inten": arr["r"].astype(np.float32).tolist(),
+                "total": n}
+
+    # ------------------------------------------------------------------
     def delete_scan(self, scan_id: str) -> None:
         import shutil
         d = self.scan_dir(scan_id)

--- a/config.json
+++ b/config.json
@@ -29,7 +29,7 @@
   "MODE_B_CONTINUOUS": {
     "SCAN_ANGLE": 184.0,
     "OVERLAP_DEG": 4.0,
-    "SPEED_DPS": 1.87,
+    "SPEED_DPS": 1.67,
     "ACCEL_DPS2": 10.0,
     "PWM_CHANNEL": 1
   },

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -99,6 +99,21 @@ button:disabled { opacity: .45; cursor: not-allowed; }
 .view canvas { width: 100%; height: 100%; display: block; border-radius: 10px; background: #05070a; }
 .hidden { display: none !important; }
 
+/* 3D-Achsen-Overlay (HTML-Labels über dem WebGL-Canvas) */
+.v3d-labels { position: absolute; inset: 0; pointer-events: none; overflow: hidden; }
+.v3d-axis-label {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  font: 600 13px/1 system-ui, sans-serif;
+  text-shadow: 0 0 3px #000, 0 0 3px #000;
+  white-space: nowrap;
+}
+.v3d-scale {
+  position: absolute; left: 10px; bottom: 10px;
+  font: 12px/1 system-ui, sans-serif; color: var(--muted);
+  text-shadow: 0 0 3px #000;
+}
+
 .out { background: #0a0d12; padding: 8px; border-radius: 6px; font-size: 11px; color: var(--muted); white-space: pre-wrap; max-height: 120px; overflow: auto; }
 
 #scanList { list-style: none; padding: 0; margin: 0; }

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -75,12 +75,20 @@ $('btnCalOff').onclick = async () => {
       angle_offset: r.angle_offset, model_y_offset: r.model_y_offset, model_z_offset: r.model_z_offset }) });
 };
 
-document.querySelectorAll('input[name=view]').forEach(r => r.onchange = () => {
+function applyViewMode() {
   viewMode = document.querySelector('input[name=view]:checked').value;
   $('view2d').classList.toggle('hidden', viewMode !== '2d');
   $('view3d').classList.toggle('hidden', viewMode !== '3d');
-  if (viewMode === '3d') v3d._resize();
-});
+  const ov = document.querySelector('.v3d-labels');
+  if (ov) ov.classList.toggle('hidden', viewMode !== '3d');
+  if (viewMode === '3d') {
+    v2d.stop();        // 2D-Loop pausieren, spart Rechenzeit
+    v3d._resize();     // Canvas war evtl. 0×0 während hidden
+  } else {
+    v2d.start();       // 2D-Loop wieder aufnehmen (idempotent)
+  }
+}
+document.querySelectorAll('input[name=view]').forEach(r => r.onchange = applyViewMode);
 
 function clearView() {
   v2d.clear(); v3d.clear(); worker.postMessage({ type: 'clear' });
@@ -168,6 +176,7 @@ async function refreshScans() {
       <div class="row">
         <span><span class="dot ${qa}"></span><b>${s.id}</b></span>
         <span style="display:flex;gap:6px;align-items:center">
+          <button class="btn-view3d" data-id="${s.id}" title="In 3D anzeigen">&#128065; 3D</button>
           <a href="/api/scans/${s.id}/download">ZIP</a>
           <button class="btn-del" data-id="${s.id}">&#128465;</button>
         </span>
@@ -179,6 +188,9 @@ async function refreshScans() {
       </div>`;
     ul.appendChild(li);
   }
+  ul.querySelectorAll('.btn-view3d').forEach(btn => {
+    btn.onclick = () => loadScanInto3D(btn.dataset.id);
+  });
   ul.querySelectorAll('.btn-del').forEach(btn => {
     btn.onclick = async () => {
       if (!confirm(`Scan "${btn.dataset.id}" wirklich löschen?`)) return;
@@ -196,5 +208,24 @@ async function refreshScans() {
     };
   });
 }
+// Gespeicherten Scan in die 3D-Ansicht laden
+async function loadScanInto3D(scanId) {
+  clearView();
+  // auf 3D-Ansicht umschalten
+  const radio3d = document.querySelector('input[name=view][value=3d]');
+  radio3d.checked = true;
+  applyViewMode();
+  try {
+    const r = await api(`/api/scans/${scanId}/pointcloud`);
+    if (!r.ok) { alert('Punktwolke nicht gefunden.'); return; }
+    const data = await r.json();
+    v3d.addPoints(new Float32Array(data.xyz), new Float32Array(data.inten));
+    totalPoints = data.total;
+    $('stPts').textContent = totalPoints.toLocaleString('de-DE');
+  } catch (e) {
+    alert('Fehler beim Laden der Punktwolke.');
+  }
+}
+
 $('btnRefresh').onclick = refreshScans;
 refreshScans();

--- a/frontend/js/viewer2d.js
+++ b/frontend/js/viewer2d.js
@@ -63,11 +63,13 @@ class Viewer2D {
     ctx.moveTo(cx, cy - R); ctx.lineTo(cx, cy + R); ctx.stroke();
 
     // Punkte
+    // Spiegel-Null (LiDAR-Winkel 0) zeigt in +Y-Richtung → im 2D-Plot nach oben.
+    // Im Uhrzeigersinn, damit oben/unten und links/rechts der Realität entsprechen.
     ctx.fillStyle = '#3fb950';
     for (const p of this.points) {
       const a = p.a * Math.PI / 180;
-      const x = cx + Math.cos(a) * p.d * scale;
-      const y = cy - Math.sin(a) * p.d * scale;
+      const x = cx + Math.sin(a) * p.d * scale;
+      const y = cy - Math.cos(a) * p.d * scale;
       ctx.fillRect(x, y, 2 * devicePixelRatio, 2 * devicePixelRatio);
     }
     // Sensor

--- a/frontend/js/viewer3d.js
+++ b/frontend/js/viewer3d.js
@@ -13,6 +13,14 @@ const FRAG = `
 precision mediump float; varying float vInt;
 void main(){ float g = clamp(vInt/255.0,0.05,1.0); gl_FragColor = vec4(g*0.5, g, g*0.7, 1.0); }`;
 
+// Eigenes Programm für Achsenlinien (einfarbig, ohne Intensität)
+const AXIS_VERT = `
+attribute vec3 aPos; uniform mat4 uMVP;
+void main(){ gl_Position = uMVP * vec4(aPos,1.0); }`;
+const AXIS_FRAG = `
+precision mediump float; uniform vec3 uColor;
+void main(){ gl_FragColor = vec4(uColor,1.0); }`;
+
 function mat4Mul(a, b) {
   const o = new Float32Array(16);
   for (let i = 0; i < 4; i++) for (let j = 0; j < 4; j++) {
@@ -51,10 +59,92 @@ class Viewer3D {
     this.theta = 0.6; this.phi = 1.0; this.dist = 8.0;
     this.target = [0, 0, 0];
     this._drag = false; this._lx = 0; this._ly = 0;
+    this.axisLen = 1.0;        // Achsenlänge / Maßstab [m]
+    this._initAxes();
+    this._initLabels();
     this._bindControls();
     this._resize();
     window.addEventListener('resize', () => this._resize());
     this._loop();
+  }
+
+  // --- Koordinatenachsen (X rot, Y grün, Z blau) ----------------------
+  _initAxes() {
+    const gl = this.gl;
+    this._axisProg = this._program(AXIS_VERT, AXIS_FRAG);
+    this._axisAPos = gl.getAttribLocation(this._axisProg, 'aPos');
+    this._axisUMVP = gl.getUniformLocation(this._axisProg, 'uMVP');
+    this._axisUColor = gl.getUniformLocation(this._axisProg, 'uColor');
+    const L = this.axisLen;
+    this._axes = [
+      { color: [0.95, 0.30, 0.27], tip: [L, 0, 0], name: 'X' },
+      { color: [0.25, 0.73, 0.31], tip: [0, L, 0], name: 'Y' },
+      { color: [0.30, 0.55, 0.95], tip: [0, 0, L], name: 'Z' },
+    ];
+    for (const ax of this._axes) {
+      const buf = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+      gl.bufferData(gl.ARRAY_BUFFER,
+        new Float32Array([0, 0, 0, ax.tip[0], ax.tip[1], ax.tip[2]]), gl.STATIC_DRAW);
+      ax.buf = buf;
+    }
+  }
+
+  // HTML-Overlay-Labels über dem Canvas (WebGL kann keinen Text)
+  _initLabels() {
+    const host = this.canvas.parentNode;
+    let ov = host.querySelector('.v3d-labels');
+    if (!ov) {
+      ov = document.createElement('div');
+      ov.className = 'v3d-labels';
+      host.appendChild(ov);
+    }
+    this._overlay = ov;
+    this._labelEls = {};
+    for (const ax of this._axes) {
+      const el = document.createElement('span');
+      el.className = 'v3d-axis-label';
+      el.textContent = ax.name;
+      el.style.color = `rgb(${ax.color.map(c => Math.round(c * 255)).join(',')})`;
+      ov.appendChild(el);
+      this._labelEls[ax.name] = el;
+    }
+    // statischer Maßstab unten links
+    this._scaleEl = document.createElement('span');
+    this._scaleEl.className = 'v3d-scale';
+    this._scaleEl.textContent = `Achsen = ${this.axisLen.toFixed(0)} m`;
+    ov.appendChild(this._scaleEl);
+  }
+
+  _projectToScreen(p, mvp) {
+    // clip = mvp · [x,y,z,1]  (mvp ist spaltenweise gespeichert)
+    const x = p[0], y = p[1], z = p[2];
+    const cx = mvp[0] * x + mvp[4] * y + mvp[8] * z + mvp[12];
+    const cy = mvp[1] * x + mvp[5] * y + mvp[9] * z + mvp[13];
+    const cw = mvp[3] * x + mvp[7] * y + mvp[11] * z + mvp[15];
+    if (cw <= 1e-6) return null;                  // hinter der Kamera
+    const W = this.canvas.width / devicePixelRatio;
+    const H = this.canvas.height / devicePixelRatio;
+    return { px: (cx / cw + 1) / 2 * W, py: (1 - cy / cw) / 2 * H };
+  }
+
+  _drawAxes(mvp) {
+    const gl = this.gl;
+    gl.useProgram(this._axisProg);
+    gl.uniformMatrix4fv(this._axisUMVP, false, mvp);
+    gl.lineWidth(2.0);
+    for (const ax of this._axes) {
+      gl.uniform3fv(this._axisUColor, ax.color);
+      gl.bindBuffer(gl.ARRAY_BUFFER, ax.buf);
+      gl.enableVertexAttribArray(this._axisAPos);
+      gl.vertexAttribPointer(this._axisAPos, 3, gl.FLOAT, false, 0, 0);
+      gl.drawArrays(gl.LINES, 0, 2);
+      // Label an die projizierte Achsenspitze setzen
+      const s = this._projectToScreen(ax.tip, mvp);
+      const el = this._labelEls[ax.name];
+      if (s) { el.style.display = 'block'; el.style.left = `${s.px}px`; el.style.top = `${s.py}px`; }
+      else { el.style.display = 'none'; }
+    }
   }
 
   _program(vs, fs) {
@@ -137,6 +227,7 @@ class Viewer3D {
       gl.vertexAttribPointer(this.aInt, 1, gl.FLOAT, false, 0, 0);
       gl.drawArrays(gl.POINTS, 0, c.count);
     }
+    this._drawAxes(mvp);
     requestAnimationFrame(() => this._loop());
   }
 }


### PR DESCRIPTION
## Zusammenfassung

Behebt mehrere gemeldete Punkte rund um Anzeige und LiDAR-Steuerung.

### 1. LiDAR-Spiegel-Steuerung (STL27L, Seriell 921600 Baud)
- Der Spiegel **läuft per Default durch** (dreht ab Werk bei Stromversorgung).
- `"0"` (stopp) wird **nur** gesendet bei **„LiDAR stoppen"** und bei **Scan-Ende/-Abbruch**.
- `"1"` (start) wird **nur** gesendet, um nach einem solchen Stopp **wieder anzufahren**.
- Im **Normalbetrieb** (2D-Live, Scan, Übergang 2D-Live → Scan) wird **kein** Start/Stop-Bit gesendet → kein versehentliches Hoch-/Runterfahren des Spiegels während des Scans.
- Umsetzung über idempotentes `_set_motor()`; `start()`/`stop()` sind re-entrant (kein zweiter Reader-Thread).

### 2. 2D/3D-Umschaltung repariert
- Beim Moduswechsel werden `v2d.start()`/`v2d.stop()` korrekt aufgerufen und das 3D-Canvas neu dimensioniert (war zuvor 0×0 während `hidden`).

### 3. 3D-Ansicht: Koordinatenachsen + Maßstab
- Eigenes WebGL-Linienprogramm zeichnet die Achsen **X (rot), Y (grün), Z (blau)**.
- HTML-Overlay mit Achsen-Labels und Maßstabsangabe.

### 4. Gespeicherte Scans in 3D anzeigen
- Neuer Endpunkt `GET /api/scans/{id}/pointcloud` (liest PLY inkl. Intensität, Fallback XYZ).
- Pro Scan ein **„👁 3D"**-Button, der die Punktwolke lädt und in die 3D-Ansicht schaltet.

## Tests
- Idempotenz der Motorbefehle (genau ein `0`/`1` je echtem Zustandswechsel) ✓
- Sollverhalten der Spiegel-Bits über alle Abläufe (2D-Live, Stopp, Scan, Übergänge) ✓
- `load_pointcloud`: PLY-Lesen, XYZ-Fallback, Leerfall ✓
- Endpunkt-Wiring (404 bei fehlender Wolke, statisches Frontend 200) ✓
- JS-Syntaxcheck aller geänderten Viewer/App-Dateien ✓
- Mock-Server: LiDAR Start/Stop und vollständiger Scan-Durchlauf ✓

## Hinweis zur Hardware
Falls der Spiegel während eines Scans dennoch hoch-/runterfährt, ist die Ursache mit hoher Wahrscheinlichkeit ein **Stromversorgungs-Einbruch** durch den gleichzeitig laufenden Schrittmotor (gemeinsame 5 V-Schiene) — nicht die Software (es wird im Normalbetrieb kein Stop-Bit gesendet). Abhilfe: stabilere/getrennte 5 V-Versorgung für den LiDAR bzw. Stützkondensator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuqgSdThFskz1TgGvBdD2d)_